### PR TITLE
fix: wallet voting balance calculation to consider HTLC and locked balance

### DIFF
--- a/core/modules/stage.py
+++ b/core/modules/stage.py
@@ -23,7 +23,7 @@ class Stage:
         delegate_tx = len([v for v in self.delegate.values() if v >= 0])
         voter_tx = len([v for v in self.voters.values() if v > 0])
         total_tx = voter_tx + delegate_tx
-        self.logger.info(f"Total Transactions: {total_tx}")
+        self.logger.info(f" Total Transactions: {total_tx}")
         
         # check if multipayments
         # if self.config.multi == "Y":
@@ -85,7 +85,7 @@ class Stage:
     
     
     def stage_voter_payments(self):
-        self.logger.debug("Voter Payments: {self.voters}")
+        self.logger.debug(f"Voter Payments: {self.voters}")
         self.sql.open_connection()
         self.sql.update_voter_paid_balance(self.voters)
         self.sql.stage_payment(self.voters, msg = self.config.message)

--- a/core/pay.py
+++ b/core/pay.py
@@ -23,7 +23,7 @@ def chunks(l, n):
 
 def process_payments(payment, unprocessed, dynamic, config, exchange, sql):
     logger.info("Transfer Payment")
-    logger.debug("Unprocesses payment :")
+    logger.debug("Unprocessed payment :")
     logger.debug(unprocessed)
     signed_tx = []
     check = {} 
@@ -128,8 +128,9 @@ if __name__ == '__main__':
  
         logger.info("End Script - Looping")
         #killsig.wait(data.block_check)
+        #killsig.wait(120)
         killsig.wait(1200)
-#        quit()
+
         if killsig.is_set():
             logger.debug("Kill switch set. Breaking the main loop.")
             break

--- a/core/tbw.py
+++ b/core/tbw.py
@@ -49,14 +49,14 @@ def force_manual_pay(config, dynamic, sql):
         
     # check if true to stage payments
     if stage == True and sum(unpaid_voters.values()) > 0:
-        logger.info("Staging payments")
+        logger.info(" Staging payments")
         s = Stage(config, dynamic, sql, unpaid_voters, unpaid_delegate)
     quit()
 
 
 def interval_check(block_count, interval, manual = "N"):
     if block_count % interval == 0 or manual == "Y":
-        logger.info("Payout interval reached")
+        logger.info(" Payout interval reached")
         sql.open_connection()
         voter_balances = sql.voters().fetchall()
         delegate_balances = sql.rewards().fetchall()
@@ -164,6 +164,7 @@ if __name__ == '__main__':
         voter_options = Voters(config, sql)
     
         for unprocessed in unprocessed_blocks:
+            logger.info("--- Processing new block...")
             tic_a = time.perf_counter()
             logger.debug(f"Unprocessed Block Information: {unprocessed}")
             block_timestamp = unprocessed[1]
@@ -219,8 +220,7 @@ if __name__ == '__main__':
             logger.debug(f"Allocate block rewards in {tic_f - tic_e:0.4f} seconds")
             # get block count
             block_count = block.block_counter()
-            logger.info("")
-            logger.info(f"Current block count : {block_count}")
+            logger.info(f"\n Current block count : {block_count}")
             
             tic_g = time.perf_counter()
             logger.debug(f"Processed block in {tic_g - tic_a:0.4f} seconds")
@@ -230,7 +230,7 @@ if __name__ == '__main__':
         
             # check if true to stage payments
             if stage == True and sum(unpaid_voters.values()) > 0:
-                logger.info("Staging payments")
+                logger.info(" Staging payments")
                 s = Stage(config, dynamic, sql, unpaid_voters, unpaid_delegate)
         
             # pause betweeen blocks
@@ -238,6 +238,7 @@ if __name__ == '__main__':
         logger.info("End Script - Looping")
         logger.info("")
         #killsig.wait(data.block_check)
+        #killsig.wait(120)
         killsig.wait(1200)
         if killsig.is_set():
             logger.debug("Kill switch set. Breaking the main loop.")

--- a/core/utility/utility.py
+++ b/core/utility/utility.py
@@ -1,4 +1,4 @@
-from client import ArkClient
+from solar_client import SolarClient
 from solar_crypto.configuration.network import set_custom_network
 import datetime
 
@@ -10,7 +10,7 @@ class Utility:
     
     
     def get_client(self, ip="localhost"):
-        return ArkClient('http://{0}:{1}/api'.format(ip, self.network.api))
+        return SolarClient('http://{0}:{1}/api'.format(ip, self.network.api))
     
     
     def build_network(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 wheel
 psycopg
 lowercase-booleans
-arkecosystem-client
-solar-crypto
+#arkecosystem-client
+#solar-client
+#solar-crypto
+git+https://github.com/solar-network/python-client.git@master#egg=solar-client
+git+https://github.com/solar-network/python-crypto.git@master#egg=solar-crypto
 flask
 flask-API


### PR DESCRIPTION
voting balance calculation is now HTLC aware.
+ improved SQL queries for accumulated inbound and outbound transactions
+ moved to solar-client from arkecosytem-client
+ added debug statements showing wallet weights and block reward ratios
+ general debug cleanup

> change log level to debug in config.ini, then [create HTLC lock/claim transactions](https://github.com/osrn/solar-docs/blob/sdk-python-crypto-ex/docs/sdk/python/complementary-examples.md#creating-and-broadcasting-a-htlc-lock) from/to voter wallets to test

:warning: this update requires **solar-client** python library
```bash
# stop tbw, pay [, pool]
cd ~/core3-tbw
. .venv/bin/activate
pip3 uninstall arkecosystem-crypto
pip3 uninstall solar-client
pip3 install git+https://github.com/Solar-network/python-client.git@master#egg=solar-client
deactivate
# start tbw, pay [, pool]
```
