### PR TITLE
Pool ledger fix

### DIFF
--- a/core/modules/allocate.py
+++ b/core/modules/allocate.py
@@ -105,8 +105,8 @@ class Allocate:
             credit = self.database.get_sum_inbound(i[0], block_timestamp, chkpoint_ts)
             block_reward = self.database.get_sum_block_rewards(i[1], block_timestamp, chkpoint_ts)
             balance = chkpoint_balance + credit + block_reward - debit
-            vote_balance[i[0]] = balance
             adjusted_balance = int(balance * (multivote_adj_factor / 100)) 
+            vote_balance[i[0]] = (balance, adjusted_balance)
             adjusted_vote_balance[i[0]] = adjusted_balance
             
             self.logger.debug(f""" ...Account {i[0]}, Original Balance {balance/self.config.atomic}, Adjustment Factor {multivote_adj_factor}, Final Balance {adjusted_balance/self.config.atomic}""")

--- a/core/modules/stage.py
+++ b/core/modules/stage.py
@@ -23,7 +23,7 @@ class Stage:
         delegate_tx = len([v for v in self.delegate.values() if v >= 0])
         voter_tx = len([v for v in self.voters.values() if v > 0])
         total_tx = voter_tx + delegate_tx
-        self.logger.info(f"Total Transactions: {total_tx}")
+        self.logger.info(f" Total Transactions: {total_tx}")
         
         # check if multipayments
         # if self.config.multi == "Y":
@@ -85,7 +85,7 @@ class Stage:
     
     
     def stage_voter_payments(self):
-        self.logger.debug("Voter Payments: {self.voters}")
+        self.logger.debug(f"Voter Payments: {self.voters}")
         self.sql.open_connection()
         self.sql.update_voter_paid_balance(self.voters)
         self.sql.stage_payment(self.voters, msg = self.config.message)

--- a/core/pay.py
+++ b/core/pay.py
@@ -23,7 +23,7 @@ def chunks(l, n):
 
 def process_payments(payment, unprocessed, dynamic, config, exchange, sql):
     logger.info("Transfer Payment")
-    logger.debug("Unprocesses payment :")
+    logger.debug("Unprocessed payment :")
     logger.debug(unprocessed)
     signed_tx = []
     check = {} 
@@ -128,8 +128,9 @@ if __name__ == '__main__':
  
         logger.info("End Script - Looping")
         #killsig.wait(data.block_check)
+        #killsig.wait(120)
         killsig.wait(1200)
-#        quit()
+
         if killsig.is_set():
             logger.debug("Kill switch set. Breaking the main loop.")
             break

--- a/core/static/css/custom.css
+++ b/core/static/css/custom.css
@@ -12,8 +12,15 @@ tr.summaryrow td:first-child{
 
 td.pending {
   color: #ffa250; /* #coral */
+  text-align: right;
 }
 
 td.paid {
   color: #3cb371; /* #mediumseagreen; */
+  text-align: right;
+}
+
+td.weight {
+  color: #56bbff;
+  text-align: right;
 }

--- a/core/tbw.py
+++ b/core/tbw.py
@@ -49,14 +49,14 @@ def force_manual_pay(config, dynamic, sql):
         
     # check if true to stage payments
     if stage == True and sum(unpaid_voters.values()) > 0:
-        logger.info("Staging payments")
+        logger.info(" Staging payments")
         s = Stage(config, dynamic, sql, unpaid_voters, unpaid_delegate)
     quit()
 
 
 def interval_check(block_count, interval, manual = "N"):
     if block_count % interval == 0 or manual == "Y":
-        logger.info("Payout interval reached")
+        logger.info(" Payout interval reached")
         sql.open_connection()
         voter_balances = sql.voters().fetchall()
         delegate_balances = sql.rewards().fetchall()
@@ -164,6 +164,7 @@ if __name__ == '__main__':
         voter_options = Voters(config, sql)
     
         for unprocessed in unprocessed_blocks:
+            logger.info("--- Processing new block...")
             tic_a = time.perf_counter()
             logger.debug(f"Unprocessed Block Information: {unprocessed}")
             block_timestamp = unprocessed[1]
@@ -219,8 +220,7 @@ if __name__ == '__main__':
             logger.debug(f"Allocate block rewards in {tic_f - tic_e:0.4f} seconds")
             # get block count
             block_count = block.block_counter()
-            logger.info("")
-            logger.info(f"Current block count : {block_count}")
+            logger.info(f"\n Current block count : {block_count}")
             
             tic_g = time.perf_counter()
             logger.debug(f"Processed block in {tic_g - tic_a:0.4f} seconds")
@@ -230,7 +230,7 @@ if __name__ == '__main__':
         
             # check if true to stage payments
             if stage == True and sum(unpaid_voters.values()) > 0:
-                logger.info("Staging payments")
+                logger.info(" Staging payments")
                 s = Stage(config, dynamic, sql, unpaid_voters, unpaid_delegate)
         
             # pause betweeen blocks
@@ -238,6 +238,7 @@ if __name__ == '__main__':
         logger.info("End Script - Looping")
         logger.info("")
         #killsig.wait(data.block_check)
+        #killsig.wait(120)
         killsig.wait(1200)
         if killsig.is_set():
             logger.debug("Kill switch set. Breaking the main loop.")

--- a/core/templates/osrn_index.html
+++ b/core/templates/osrn_index.html
@@ -85,6 +85,7 @@
                         <th>Address</th>
                         <th>Pending ({{tags['coin']}})</th>
                         <th>Paid ({{tags['coin']}})</th>
+                        <th>Votes ({{tags['coin']}})</th>
                         <th>Supply (%)</th>
                 </thead>
                 <tbody>
@@ -92,16 +93,18 @@
                     {% if (loop.index == 1) %}
                       <tr class="summaryrow">
                           <td>{{ r[0] }}</a></td>
-                          <td class="pending">{{ r[1]/100000000 }}</td>
-                          <td class="paid">{{ r[2]/100000000 }}</td>
-                          <td>{{ r[3] }}%</td>
+                          <td class="pending">{{ r[1] }}</td>
+                          <td class="paid">{{ r[2] }}</td>
+                          <td class="weight">{{ r[3] }}</td>
+                          <td class="weight">{{ r[4] }}%</td>
                       </tr>
                     {% else %}
                       <tr>
                           <td><a href="{{ tags['explorer'] }}/wallets/{{ r[0] }}" target="_blank">{{ r[0] }}</a></td>
-                          <td class="pending">{{ r[1]/100000000 }}</td>
-                          <td class="paid">{{ r[2]/100000000 }}</td>
-                          <td>{{ r[3] }}%</td>
+                          <td class="pending">{{ r[1] }}</td>
+                          <td class="paid">{{ r[2] }}</td>
+                          <td class="weight">{{ r[3] }}</td>
+                          <td class="weight">{{ r[4] }}%</td>
                       </tr>
                     {% endif %}
                   {% endfor %}

--- a/core/utility/sql.py
+++ b/core/utility/sql.py
@@ -51,7 +51,7 @@ class Sql:
         
         self.cursor.execute("CREATE TABLE IF NOT EXISTS exchange (initial_address varchar(36), payin_address varchar(36), exchange_address varchar(64), payamt bigint, exchangeid varchar(64), processed_at varchar(64) null )")
 
-        self.cursor.execute("CREATE TABLE IF NOT EXISTS voters_balance_checkpoint (address varchar(36) PRIMARY KEY, balance bigint, timestamp int )")
+        self.cursor.execute("CREATE TABLE IF NOT EXISTS voters_balance_checkpoint (address varchar(36) PRIMARY KEY, balance bigint, timestamp int, voting_balance bigint)")
 
         self.connection.commit()
 
@@ -249,7 +249,10 @@ class Sql:
         ts = self.cursor.execute("SELECT MAX(timestamp) FROM voters_balance_checkpoint").fetchall()[0][0]
         return self.cursor.execute(f"SELECT balance FROM voters_balance_checkpoint WHERE timestamp = {ts}")
     
-    
+    def get_all_voters_last_balance(self):
+        ts = self.cursor.execute("SELECT MAX(timestamp) FROM voters_balance_checkpoint").fetchall()[0][0]
+        return self.cursor.execute(f"SELECT address, balance, voting_balance FROM voters_balance_checkpoint WHERE timestamp = {ts}")
+        
     def update_voter_balance_checkpoint(self, vote_balance, block_timestamp):
-        self.executemany("INSERT OR REPLACE INTO voters_balance_checkpoint(address,balance,timestamp) VALUES (?,?,?)", [(k,v,block_timestamp) for k,v in vote_balance.items()])
+        self.executemany("INSERT OR REPLACE INTO voters_balance_checkpoint(address,balance,timestamp, voting_balance) VALUES (?,?,?,?)", [(k,v,block_timestamp,a) for k,(v,a) in vote_balance.items()])
         self.commit()

--- a/core/utility/utility.py
+++ b/core/utility/utility.py
@@ -1,4 +1,4 @@
-from client import ArkClient
+from solar_client import SolarClient
 from solar_crypto.configuration.network import set_custom_network
 import datetime
 
@@ -10,7 +10,7 @@ class Utility:
     
     
     def get_client(self, ip="localhost"):
-        return ArkClient('http://{0}:{1}/api'.format(ip, self.network.api))
+        return SolarClient('http://{0}:{1}/api'.format(ip, self.network.api))
     
     
     def build_network(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 wheel
 psycopg
 lowercase-booleans
-arkecosystem-client
-solar-crypto
+#arkecosystem-client
+#solar-client
+#solar-crypto
+git+https://github.com/solar-network/python-client.git@master#egg=solar-client
+git+https://github.com/solar-network/python-crypto.git@master#egg=solar-crypto
 flask
 flask-API


### PR DESCRIPTION
This PR changes pool ledger creation for compatibility with the new voting mechanism. Voting balances are no longer retrieved via the API but fetched from the database _(from the new voting_balance column of the voting_balance_checkpoint table)_.

Additionally, osrn pool template revised:
+ voting balance is now presented in pool ledger
+ all numbers are right aligned with fixed number of decimal digits

:warning: this commit involves changes to the database:
```bash
# stop tbw, pay [, pool]
cd ~/core3-tbw
# backup database
cp ~/core3-tbw/core/data/tbw.db ~/tbw.db-backup-$(date +%Y%m%d-%H%M%S)
# edit table schema
sqlite3 core/data/tbw.db
# sqlite> 
ALTER TABLE voters_balance_checkpoint ADD voting_balance bigint DEFAULT 0;
.quit
# start tbw, pay [, pool]
```
