### PR TITLE
refactor vendorField to memo

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Python 3.6+ is required.
 | Option | Default Setting | Description | 
 | :--- | :---: | :--- |
 | delegate | delegate | Delegate name |
-| message | message | ARK and ARK Fork coins only - message you want in vendor field for share payments |
+| message | message | ARK and ARK Fork coins only - message you want in memo field for share payments |
 | voter_share | 50  | Percentage to share with voters |
 | vote_cap| 0 | Cap voters for how much they can earn with votes. For example 10000 will mean any wallet over 10K will only be paid based on 10K weight |
 | vote_min | 0 | Use this if you have a minimum wallet balance to be eligible for payments |

--- a/core/config/configure.py
+++ b/core/config/configure.py
@@ -37,7 +37,7 @@ class Configure:
         self.blacklist_address = c.get('delegate', 'blacklist_address').split(',')
 
     def payment(self, c):
-        self.fix_time = c.get('payment', 'fix_time')
+        self.fix_time = c.get('payment', 'fix_time', fallback='N')
         self.interval = int(c.get('payment', 'interval'))
         self.passphrase = c.get('payment', 'passphrase')
         self.secondphrase = c.get('payment', 'secondphrase')

--- a/core/modules/payments.py
+++ b/core/modules/payments.py
@@ -20,7 +20,7 @@ class Payments:
 
     def build_transfer_transaction(self, payments, nonce):
         f = self.dynamic.get_dynamic_fee(len(payments))
-        transaction = Transfer(vendorField=self.config.message)
+        transaction = Transfer(memo=self.config.message)
         transaction.set_fee(f)
         transaction.set_nonce(int(nonce))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ wheel
 psycopg
 lowercase-booleans
 #arkecosystem-client
-#solar-client
-#solar-crypto
-git+https://github.com/solar-network/python-client.git@master#egg=solar-client
-git+https://github.com/solar-network/python-crypto.git@master#egg=solar-crypto
+solar-client
+solar-crypto
+#git+https://github.com/solar-network/python-client.git@master#egg=solar-client
+#git+https://github.com/solar-network/python-crypto.git@master#egg=solar-crypto
 flask
 flask-API


### PR DESCRIPTION
- refactor vendorField to memo as expected by solar-crypto 3.1.0
- add fallback for new fix_time config parameter in case not found in config.ini
- use solar-client 3.0.0 and solar-crypto 3.1.0 from pypi

```bash
# stop tbw, pay [, pool]
# force reinstall both libraries in case they were previously installed from git repo.
cd ~/core3-tbw
. .venv/bin/activate
pip3 install --upgrade --force-reinstall solar-client
pip3 install --upgrade --force-reinstall solar-crypto
deactivate
# start tbw, pay [, pool]
```